### PR TITLE
Fix: Map short script names to full directory names

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -475,7 +475,15 @@ def scaffold_project_from_local_files(
 
         # 2. Copy scripts into .specify/scripts
         dest_scripts_dir = dest_specify_dir / "scripts"
-        source_script_type_dir = source_scripts_path / script_type
+
+        # Map short script type names to their full directory names
+        script_type_map = {
+            "ps": "powershell",
+            "sh": "bash",
+        }
+        script_type_full_name = script_type_map.get(script_type, script_type)
+
+        source_script_type_dir = source_scripts_path / script_type_full_name
         if not source_script_type_dir.is_dir():
              raise FileNotFoundError(f"Script type '{script_type}' directory not found in {source_scripts_path}.")
         shutil.copytree(source_script_type_dir, dest_scripts_dir, dirs_exist_ok=True)


### PR DESCRIPTION
The `specify init` command was failing when a short-hand script type (e.g., 'ps' or 'sh') was provided via the --script argument. The command was using the short name to look for a directory, but the directories are named with the full names ('powershell', 'bash').

This commit fixes the issue by introducing a mapping from the short names to the full names within the
`scaffold_project_from_local_files` function. The command now correctly resolves 'ps' to 'powershell' and 'sh' to 'bash' when constructing the path to the script templates, ensuring the initialization process succeeds as expected.