### PR TITLE
fix(cli): Correctly install agent-specific command templates

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -444,10 +444,8 @@ def _convert_md_to_toml(md_content: str) -> str:
     if not frontmatter_match:
         # If no frontmatter, treat the whole file as the prompt
         frontmatter_text = ""
-        content = md_content.strip()
     else:
         frontmatter_text = frontmatter_match.group(1)
-        content = frontmatter_match.group(2).strip()
 
     # Description from frontmatter
     description_match = re.search(r"description:\s*(.*)", frontmatter_text)
@@ -465,8 +463,8 @@ def _convert_md_to_toml(md_content: str) -> str:
     if description:
         toml_parts.append(f'description = "{description}"')
 
-    # Add prompt with multiline string syntax
-    toml_parts.append(f'prompt = """\n{content}\n"""')
+    # Add prompt with multiline string syntax, keeping the full original content
+    toml_parts.append(f'prompt = """\n{md_content.strip()}\n"""')
 
     # Add tool configuration, preferring PowerShell on Windows
     # Note: This logic can be simplified if both script types are always present


### PR DESCRIPTION
The `specify init` command was incorrectly copying all command templates into the generic `.specify/templates` directory, regardless of the selected AI agent. This also caused a bug where command files were not converted to the required TOML format for agents like Gemini and Claude.

This commit refactors the project scaffolding logic to:
- Introduce a new `_convert_md_to_toml` helper function to correctly convert Markdown command templates to TOML format, preserving the full markdown content in the prompt.
- Update the `scaffold_project_from_local_files` function to selectively install command templates into the correct agent-specific directory (e.g., `.gemini/commands`).
- Ensure that only the base templates are copied to the `.specify/templates` directory, preventing the installation of unnecessary files.